### PR TITLE
feat: support dynamo-worker-id header to specify route target

### DIFF
--- a/components/http/src/main.rs
+++ b/components/http/src/main.rs
@@ -44,7 +44,7 @@ async fn app(runtime: Runtime) -> Result<()> {
     let http_service = HttpService::builder()
         .port(args.port)
         .host(args.host)
-        .build()?;
+        .build(distributed.etcd_client())?;
     let manager = http_service.state().manager_clone();
 
     // todo - use the IntoComponent trait to register the component

--- a/launch/dynamo-run/src/input/http.rs
+++ b/launch/dynamo-run/src/input/http.rs
@@ -37,7 +37,7 @@ pub async fn run(
         .enable_embeddings_endpoints(true)
         .with_request_template(template)
         .runtime(Some(Arc::new(distributed_runtime)))
-        .build()?;
+        .build(None)?;
     match engine_config {
         EngineConfig::Dynamic => {
             let distributed_runtime = DistributedRuntime::from_settings(runtime.clone()).await?;

--- a/lib/bindings/python/rust/http.rs
+++ b/lib/bindings/python/rust/http.rs
@@ -39,7 +39,7 @@ impl HttpService {
     #[pyo3(signature = (port=None))]
     pub fn new(port: Option<u16>) -> PyResult<Self> {
         let builder = service_v2::HttpService::builder().port(port.unwrap_or(8080));
-        let inner = builder.build().map_err(to_pyerr)?;
+        let inner = builder.build(None).map_err(to_pyerr)?;
         Ok(Self { inner })
     }
 


### PR DESCRIPTION
#### Overview:

支持通过请求头指定路由目标实例:

1. 提供`/v1/workers`接口返回所有VllmWorker的id
2. 当携带了`dynamo-worker-id`请求头时，请求最终会被转发给指定的VllmWorker
3. 如果没有携带该请求头，则原有的行为保持不变

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
